### PR TITLE
Put arrays back in

### DIFF
--- a/_bookdown.yml
+++ b/_bookdown.yml
@@ -7,6 +7,7 @@ rmd_files: ["index.Rmd",
             "03-first-task.Rmd",
             "04-linear-chain.Rmd",
             "05-structs.Rmd",
+            "06-arrays.Rmd",
             "09-appendix-backends.Rmd",
             "About.Rmd",
             "References.Rmd"]


### PR DESCRIPTION
The sidebar was acting a little bit funny in #13, and my fix for it accidentally removed chapter 6 from the sidebar. This should add it back in.

Does not account for chapter 7! Another change may be needed once that one is merged to main.