### PR TITLE
Explain flatten(), fix wrong chap number, etc

### DIFF
--- a/03-first-task.Rmd
+++ b/03-first-task.Rmd
@@ -92,7 +92,7 @@ Heredoc-style syntax for command sections can be clearer than the alternative, a
 </details>
 
 
-To prevent issues with spaces in String and File types, it is often a good idea to put quotation marks around a String or File variabls, like so:
+To prevent issues with spaces in String and File types, it is often a good idea to put quotation marks around a String or File variables, like so:
 
 ```
 task cowsay {

--- a/04-linear-chain.Rmd
+++ b/04-linear-chain.Rmd
@@ -9,7 +9,7 @@ Now that you have a first task in a workflow up and running, the next step is to
 1.  `BwaMem` aligns the samples to the reference genome.
 2.  `MarkDuplicates` marks PCR duplicates.
 3.  `ApplyBaseRecalibrator` applies base recalibration.
-4.  `Mutect2` performs somatic mutation calling. For this current iteration, we start with `Mutect2TumorOnly` which only uses the tumor sample.
+4.  `Mutect2` performs somatic mutation calling. For this current iteration, we start with `Mutect2TumorOnly` which only uses the tumor sample. Later on, we will switch to a version of mutect that will allow for comparing tumor samples against a non-tumor normal sample.
 5.  `annovar` annotates the called somatic mutations.
 
 We do this via a **linear chain**, in which we feed the output of one task to the input of the next task. Let's see how to build a linear chain in a workflow.

--- a/06-arrays.Rmd
+++ b/06-arrays.Rmd
@@ -19,16 +19,23 @@ In this chapter, we'll be going over:
 ## The array type
 Arrays are essentially lists of another [primitive type](https://en.wikipedia.org/wiki/Primitive_data_type). It is most common to see Array[File] in WDLs, but an array can contain integers, floats, strings, and the like. An array can only have one of a given primitive type. For example, an Array[String] could contain the strings "cat" and "dog" but not the integer 1965 (however, it could have "1965" as a string).
 
-In chapter 4, we went over the struct data type and used it to handle a myriad of reference genome files. Arrays differ from structs in that arrays are numerically indexed, which means that a member of the array can be accessed by its position in the array. On the other hand, each variable within a struct has its own name, and you use that name to reference it rather than a numerical index.
+In chapter 5, we went over the struct data type and used it to handle a myriad of reference genome files. Arrays differ from structs in that arrays are numerically indexed, which means that a member of the array can be accessed by its position in the array. On the other hand, each variable within a struct has its own name, and you use that name to reference it rather than a numerical index.
 
 In WDL, arrays are 0 indexed, so the "first" value in an array is referenced by `[0]`. As per the WDL spec, arrays retain their order and are [immutable](https://en.wikipedia.org/wiki/Immutable_object) -- if you explicitly define an Array[String] with the members ["foo", "bar", "bizz"], you can be confident that "foo" will always be at index 0.
 
 ```
 Array[String] foobarbizz = ["foo", "bar", "bizz"]
-String foo = foobarbizz[0] # will always be "foo"
+String foo = foobarbizz[0]  # will always be "foo"
 ```
 
-Because arrays are [immutable](https://en.wikipedia.org/wiki/Immutable_object), if you wish to add values to an array, you will need to define a new array.
+Because arrays are immutable in WDL, if you wish to add values to an array, you will need to define a new array. You can combine an existing array and new values using `flatten()`, a WDL built-in function that will turned a nested array into a "flat" array, like so:
+
+```
+Array[String] foobarbizz = ["foo", "bar", "bizz"]
+String foo = foobarbizz[0]  # will always be "foo"
+Array[Array[String]] foobarbizz_but_with_bonus_foo = [foobarbizz, foo, foo, foo]  # [["foo", "bar", "bizz"], "foo", "foo", "foo"]
+Array[String] foobarbizzfoofoofoo = flatten(foobarbizz_but_with_bonus_foo)        # ["foo", "bar", "bizz", "foo", "foo", "foo"]
+```
 
 ## Scattered tasks
 Scattered tasks allow us to run a WDL task in parallel. This is especially useful on highly scalable backends such as HPCs or the cloud, as it allows us to potentially run hundreds or even thousands of instances of a task at the same time. The most common use case for this is processing many samples at the same time, but it can also be used for processing a single sample's chromosomes in parallel, or similar situations where breaking up data into discrete "chunks" makes sense.
@@ -106,7 +113,9 @@ Next, we will want to look at our chain of tasks. Each of these tasks are design
   }
 ```
 
-A scatter is essentially the WDL version of a [for loop](https://en.wikipedia.org/wiki/For_loop). Every task within that loop will have access to a single File within the Array[File] that it is looping through. Within the scatter, downstream tasks can access outputs of upstream tasks like normal. They can only "see" one file at a time. However, outside the scatter, every task is considered in the context of every sample, so every output of those scattered tasks become arrays. As a result, our outputs are now Array[File] instead of just File.
+A scatter is essentially the WDL version of a [for loop](https://en.wikipedia.org/wiki/For_loop). Every task within that loop will have access to a single File within the Array[File] that it is looping through. Within the scatter, downstream tasks can access outputs of upstream tasks like normal. So, the first tumor fastq file will go through BwaMem, then the resulting bam will go through MarkDuplicates, and the marked bam will undergo base recalibration. Since all three of these tasks are within the same scatter, each task only "sees" one sample at a time.
+
+However, outside the scatter, every task is considered in the context of all samples, so every output of those scattered tasks becomes arrays. As a result, our workflow-level outputs are now Array[File] instead of just File.
 
 ```
   output {
@@ -123,7 +132,7 @@ You can reference a full copy of this workflow at the end of this chapter.
 
 ## Referencing an array in a task
 
-Because each task only takes in one sample, we are not directly inputting arrays into a file. However, it's important to know how to do this. If a task's input variable is an array, we must include an array separator. In WDL 1.0, this is done using the `sep=` expression placeholder. Every value in the WDL Array[String] will be separated by whatever value is declared via `sep`. In this example, that is a simple space, as that is one way how to construct a bash variable.
+In our example, each task only takes in one sample, so we are not directly inputting arrays into a file. However, it's important to know how to input arrays in a task's command section. If a task's input variable is an array, we must include an array separator. In WDL 1.0, this is done using the `sep=` expression placeholder. Every value in the WDL Array[String] will be separated by whatever value is declared via `sep`. In this example, that is a simple space, as that is one way how to construct a bash variable.
 
 ```
 task count_words {
@@ -165,6 +174,7 @@ task count_words_python {
 ```
 
 ## The workflow so far
+Let's take another look at our workflow.
 ```
 version 1.0
 

--- a/07-task-aliasing.Rmd
+++ b/07-task-aliasing.Rmd
@@ -31,7 +31,7 @@ You can only alias a task that is already defined, so we will start with the Bwa
 
 > Note: In the real world, typically two samples would be processed from a patient: One tumor and one normal. However, we are writing a workflow that only takes in one normal sample and multiple tumor samples. This implies that we have taken multiple tumor samples from the same patient, and we're comparing all of them against a single normal sample.
 
-Here we are creating an alias for the task BwaMem. We want to do this so it can run this task on the "normal" samples and store them seperately. 
+Here we are creating an alias for the task BwaMem. We want to do this so it can run this task on the "normal" samples and store them separately. 
 
 First, make sure that in your workflow input, you reference to the normal samples as input.
 


### PR DESCRIPTION
Small text changes.

* Explains that we'll be using two different versions of mutect 
* Fixes wrong chapter number
* Explains flatten(), and gives an example of how one might use it since arrays are immutable
* Fxi badd speling adn typso
* Other small clarifications